### PR TITLE
Make setting sprite frame counts and indices more resilient

### DIFF
--- a/src/nodes/2D/sprite_2d_node.c
+++ b/src/nodes/2D/sprite_2d_node.c
@@ -30,7 +30,7 @@ void sprite_2d_node_clamp_current_y(engine_sprite_2d_node_class_obj_t *sprite){
     uint16_t count_y = mp_obj_get_int(sprite->frame_count_y);
     uint16_t current_y = mp_obj_get_int(sprite->frame_current_y);
     if(current_y >= count_y){
-        sprite->frame_current_x = mp_obj_new_int(count_y-1);
+        sprite->frame_current_y = mp_obj_new_int(count_y-1);
     }
 }
 


### PR DESCRIPTION
When setting `frame_count_x` or `frame_count_y` it was possible for the sprite to be drawn at an invalid offset if the sprite texture was changed at the same time.

In the example below, when the character is running it uses a 4 frame texture but when idle it switches it to a single frame texture. Because the `frame_current_x` index could have been animated to an index greater than `0`, the calculated offset for a single frame during drawing is incorrect.

This PR fixes this by clamping `frame_current_x` and `frame_current_y` to `frame_count_x` and `frame_count_y` (minus 1) respectively, when setting any of those attributes.

**Before**
https://github.com/TinyCircuits/TinyCircuits-Tiny-Game-Engine/assets/2231590/71c34ae4-00df-4e66-805c-0b4f14743e66

**After**
https://github.com/TinyCircuits/TinyCircuits-Tiny-Game-Engine/assets/2231590/11aded34-f12f-4536-8e1e-68f7d51a6f40