### PR TITLE
Fix camera zooming.

### DIFF
--- a/src/nodes/2D/circle_2d_node.c
+++ b/src/nodes/2D/circle_2d_node.c
@@ -28,7 +28,6 @@ void circle_2d_node_class_draw(mp_obj_t circle_node_base_obj, mp_obj_t camera_no
     engine_node_base_t *camera_node_base = camera_node;
     engine_camera_node_class_obj_t *camera = camera_node_base->node;
 
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -56,11 +55,8 @@ void circle_2d_node_class_draw(mp_obj_t circle_node_base_obj, mp_obj_t camera_no
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        circle_rotated_x -= camera_resolved_hierarchy_x;
-        circle_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&circle_rotated_x, &circle_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        circle_rotated_x = (circle_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        circle_rotated_y = (circle_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&circle_rotated_x, &circle_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/gui_bitmap_button_2d_node.c
+++ b/src/nodes/2D/gui_bitmap_button_2d_node.c
@@ -37,7 +37,6 @@ void gui_bitmap_button_2d_node_class_draw(mp_obj_t button_node_base_obj, mp_obj_
         engine_node_base_t *camera_node_base = camera_node;
         engine_camera_node_class_obj_t *camera = camera_node_base->node;
 
-        vector3_class_obj_t *camera_position = camera->position;
         rectangle_class_obj_t *camera_viewport = camera->viewport;
         float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -62,11 +61,8 @@ void gui_bitmap_button_2d_node_class_draw(mp_obj_t button_node_base_obj, mp_obj_
             node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
             camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-            button_rotated_x -= camera_resolved_hierarchy_x;
-            button_rotated_y -= camera_resolved_hierarchy_y;
-
-            // Scale transformation due to camera zoom
-            engine_math_scale_point(&button_rotated_x, &button_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+            button_rotated_x = (button_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+            button_rotated_y = (button_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
             // Rotate rectangle origin about the camera
             engine_math_rotate_point(&button_rotated_x, &button_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/gui_button_2d_node.c
+++ b/src/nodes/2D/gui_button_2d_node.c
@@ -38,7 +38,6 @@ void gui_button_2d_node_class_draw(mp_obj_t button_node_base_obj, mp_obj_t camer
         engine_camera_node_class_obj_t *camera = camera_node_base->node;
 
 
-        vector3_class_obj_t *camera_position = camera->position;
         rectangle_class_obj_t *camera_viewport = camera->viewport;
         float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -61,11 +60,8 @@ void gui_button_2d_node_class_draw(mp_obj_t button_node_base_obj, mp_obj_t camer
             node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
             camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-            button_rotated_x -= camera_resolved_hierarchy_x;
-            button_rotated_y -= camera_resolved_hierarchy_y;
-
-            // Scale transformation due to camera zoom
-            engine_math_scale_point(&button_rotated_x, &button_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+            button_rotated_x = (button_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+            button_rotated_y = (button_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
             // Rotate rectangle origin about the camera
             engine_math_rotate_point(&button_rotated_x, &button_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/line_2d_node.c
+++ b/src/nodes/2D/line_2d_node.c
@@ -39,7 +39,6 @@ void line_2d_node_class_draw(mp_obj_t line_node_base_obj, mp_obj_t camera_node){
     float line_length = engine_math_distance_between(line_start->x.value, line_start->y.value, line_end->x.value, line_end->y.value);
 
     // Grab camera
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -62,11 +61,8 @@ void line_2d_node_class_draw(mp_obj_t line_node_base_obj, mp_obj_t camera_node){
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        line_rotated_x -= camera_resolved_hierarchy_x;
-        line_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&line_rotated_x, &line_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        line_rotated_x = (line_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        line_rotated_y = (line_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&line_rotated_x, &line_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/physics_circle_2d_node.c
+++ b/src/nodes/2D/physics_circle_2d_node.c
@@ -32,7 +32,6 @@ void physics_circle_2d_node_class_draw(mp_obj_t circle_node_base_obj, mp_obj_t c
     engine_node_base_t *camera_node_base = camera_node;
     engine_camera_node_class_obj_t *camera = camera_node_base->node;
 
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -43,7 +42,7 @@ void physics_circle_2d_node_class_draw(mp_obj_t circle_node_base_obj, mp_obj_t c
         color_class_obj_t *outline_color = physics_node_base->outline_color;
         color = outline_color->value;
     }
-    
+
     float circle_resolved_hierarchy_x = 0.0f;
     float circle_resolved_hierarchy_y = 0.0f;
     float circle_resolved_hierarchy_rotation = 0.0f;
@@ -62,11 +61,8 @@ void physics_circle_2d_node_class_draw(mp_obj_t circle_node_base_obj, mp_obj_t c
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        circle_rotated_x -= camera_resolved_hierarchy_x;
-        circle_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&circle_rotated_x, &circle_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        circle_rotated_x = (circle_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        circle_rotated_y = (circle_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&circle_rotated_x, &circle_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);
@@ -344,7 +340,7 @@ mp_obj_t physics_circle_2d_node_class_new(const mp_obj_type_t *type, size_t n_ar
     enum arg_ids {child_class, position, radius, velocity, angular_velocity, rotation, density, friction, bounciness, dynamic, solid, gravity_scale, outline, outline_color, collision_mask};
     bool inherited = false;
 
-    // If there is one positional argument and it isn't the first 
+    // If there is one positional argument and it isn't the first
     // expected argument (as is expected when using positional
     // arguments) then define which way to parse the arguments
     if(n_args >= 1 && mp_obj_get_type(args[0]) != &vector2_class_type){

--- a/src/nodes/2D/rectangle_2d_node.c
+++ b/src/nodes/2D/rectangle_2d_node.c
@@ -36,7 +36,6 @@ void rectangle_2d_node_class_draw(mp_obj_t rectangle_node_base_obj, mp_obj_t cam
     color_class_obj_t *rectangle_color = rectangle_2d_node->color;
     bool rectangle_outlined = mp_obj_get_int(rectangle_2d_node->outline);
 
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -58,11 +57,8 @@ void rectangle_2d_node_class_draw(mp_obj_t rectangle_node_base_obj, mp_obj_t cam
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        rectangle_rotated_x -= camera_resolved_hierarchy_x;
-        rectangle_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&rectangle_rotated_x, &rectangle_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        rectangle_rotated_x = (rectangle_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        rectangle_rotated_y = (rectangle_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&rectangle_rotated_x, &rectangle_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/sprite_2d_node.c
+++ b/src/nodes/2D/sprite_2d_node.c
@@ -57,7 +57,6 @@ void sprite_2d_node_class_draw(mp_obj_t sprite_node_base_obj, mp_obj_t camera_no
     texture_resource_class_obj_t *sprite_texture = sprite_2d_node->texture_resource;
     vector2_class_obj_t *sprite_scale =  sprite_2d_node->scale;
 
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -98,11 +97,8 @@ void sprite_2d_node_class_draw(mp_obj_t sprite_node_base_obj, mp_obj_t camera_no
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        sprite_rotated_x -= camera_resolved_hierarchy_x;
-        sprite_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&sprite_rotated_x, &sprite_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        sprite_rotated_x = (sprite_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        sprite_rotated_y = (sprite_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&sprite_rotated_x, &sprite_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);

--- a/src/nodes/2D/text_2d_node.c
+++ b/src/nodes/2D/text_2d_node.c
@@ -46,7 +46,6 @@ void text_2d_node_class_draw(mp_obj_t text_2d_node_base_obj, mp_obj_t camera_nod
     engine_node_base_t *camera_node_base = camera_node;
     engine_camera_node_class_obj_t *camera = camera_node_base->node;
 
-    vector3_class_obj_t *camera_position = camera->position;
     rectangle_class_obj_t *camera_viewport = camera->viewport;
     float camera_zoom = mp_obj_get_float(camera->zoom);
 
@@ -68,11 +67,8 @@ void text_2d_node_class_draw(mp_obj_t text_2d_node_base_obj, mp_obj_t camera_nod
         node_base_get_child_absolute_xy(&camera_resolved_hierarchy_x, &camera_resolved_hierarchy_y, &camera_resolved_hierarchy_rotation, NULL, camera_node);
         camera_resolved_hierarchy_rotation = -camera_resolved_hierarchy_rotation;
 
-        text_rotated_x -= camera_resolved_hierarchy_x;
-        text_rotated_y -= camera_resolved_hierarchy_y;
-
-        // Scale transformation due to camera zoom
-        engine_math_scale_point(&text_rotated_x, &text_rotated_y, camera_position->x.value, camera_position->y.value, camera_zoom);
+        text_rotated_x = (text_rotated_x - camera_resolved_hierarchy_x) * camera_zoom;
+        text_rotated_y = (text_rotated_y - camera_resolved_hierarchy_y) * camera_zoom;
 
         // Rotate rectangle origin about the camera
         engine_math_rotate_point(&text_rotated_x, &text_rotated_y, 0, 0, camera_resolved_hierarchy_rotation);


### PR DESCRIPTION
Before this change camera zooming is broken, this can be easily checked on the Games/UI app. The probable reason for this bug appearing is that the scaling function was broken (fixed in 323e5ddec283f1e329b78382c2a9a94d612206aa), and it worked with the broken scaling function in place. Fixing the scaling function broke the rendering code.
The camera position is already included in the resolved hierarchy, that's why it should not be taken into account when scaling.