### PR TITLE
Fixed Vector3 normalized() function

### DIFF
--- a/src/math/vector3.c
+++ b/src/math/vector3.c
@@ -58,7 +58,7 @@ mp_obj_t vector3_class_normalized(mp_obj_t self_in){
 
     float normalized_x = self->x.value;
     float normalized_y = self->y.value;
-    float normalized_z = self->y.value;
+    float normalized_z = self->z.value;
 
     engine_math_3d_normalize(&normalized_x, &normalized_y, &normalized_z);
 


### PR DESCRIPTION
Fixes [Issue #79](https://github.com/TinyCircuits/TinyCircuits-Tiny-Game-Engine/issues/79).

`self.normalized_z` was being assigned `self->y.value` instead of `self->z.value`.