### PR TITLE
Test3D change absolute filepaths to relative

### DIFF
--- a/filesystem/Games/TestGames/Test3D/main.py
+++ b/filesystem/Games/TestGames/Test3D/main.py
@@ -93,8 +93,8 @@ class MyCam(CameraNode):
 camera = MyCam()
 camera.position = Vector3(0, 5, 25)
 
-arrow_texture = TextureResource("Games/TestGames/Test3D/cw.bmp")
-floor_texture = TextureResource("Games/TestGames/Test3D/checker.bmp")
+arrow_texture = TextureResource("cw.bmp")
+floor_texture = TextureResource("checker.bmp")
 
 arrow_mesh = MeshResource()
 floor_mesh = MeshResource()


### PR DESCRIPTION
**Problem:** 

Running the game `Test3D` from the launcher gives:

```
Traceback (most recent call last):
  File "main.py", line 58, in <module>
  File "//Games/TestGames/Test3D/main.py", line 96, in <module>
OSError: [Errno 2] ENOENT
```

This is probably because when running it via Thonny serial connection, the working directory is `/`, so the absolute pathing works fine in that case.

**Solution:**

Change file paths to relative, so `Test3D` can be run from the launcher.