### PR TITLE
Improve drawing of lines

### DIFF
--- a/src/draw/engine_display_draw.c
+++ b/src/draw/engine_display_draw.c
@@ -1,6 +1,7 @@
 #include "draw/engine_display_draw.h"
 #include "display/engine_display_common.h"
 #include "debug/debug_print.h"
+#include <math.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -58,12 +59,7 @@ void engine_draw_line(uint16_t color, float x_start, float y_start, float x_end,
     float dy = y_end - y_start;
 
     // See which axis requires most steps to draw complete line, store it
-    float step_count = 0.0f;
-    if(abs((int)dx) >= abs((int)dy)){
-        step_count = abs((int)dx);
-    }else{
-        step_count = abs((int)dy);
-    }
+    float step_count = ceilf(fmax(fabs(dx), fabs(dy)));
 
     // Calculate how much to increment each axis each step
     float slope_x = dx / step_count;
@@ -73,11 +69,11 @@ void engine_draw_line(uint16_t color, float x_start, float y_start, float x_end,
     float line_y = y_start;
 
     // Draw the line
-    for(uint32_t step=0; step<step_count; step++){
+    for(uint32_t step=0; step<=step_count; step++){
+        engine_draw_pixel(color, (int32_t)line_x, (int32_t)line_y, alpha, shader);
+        
         line_x = line_x + slope_x;
         line_y = line_y + slope_y;
-
-        engine_draw_pixel(color, (int32_t)line_x, (int32_t)line_y, alpha, shader);
     }
 }
 


### PR DESCRIPTION
Note: I'm not very familiar with C, so this might be garbage, but hopefully the intent is clear?


- Draw a pixel at the start of the line

Should this be controlled by a flag? There could be an issue when using opacity, but it seems more intuitive to render the line from the start to the end. I think this is what the linked algorithm does too, i.e. <= step

```
  while (i <= step) {
    putpixel(round(x), round(y), 5);
```

- Avoid gaps rendering fractional coordinates

I found that when rendering some fractional points the line was not contiguous, e.g.

`engine_draw.line(engine_draw.white, 73.5, 65.9, 71.2, 71.2, 1.0)`

<img width="128" height="128" alt="simulator_screenshot (3)" src="https://github.com/user-attachments/assets/e1cb9874-664b-4073-9332-2e815155d5a5" />

I think something like this change would fix it.
