### PR TITLE
Improve pixel lookup and blit speed for sub-16-bit textures and non-rotated/non-scaled textures.

### DIFF
--- a/src/draw/engine_display_draw.c
+++ b/src/draw/engine_display_draw.c
@@ -103,7 +103,82 @@ void engine_draw_blit(texture_resource_class_obj_t *texture, uint32_t offset, fl
 
         As that link mentions, we'll do the rotation by doing three shears/displacements per-pixel per column.
         The displacements are performed twice on the x-axis and once on the y axis in x y x order.
+
+        Start with a fast blit path for textures that have no rotation and either no scaling or
+        are just flipped horizontally (x_scale == -1.0).
     */
+    // Find min and max x and y positions of the texture on the display
+    int32_t left_x = (int32_t)(center_x - ceilf(window_width/2.0f));
+    int32_t right_x = left_x + window_width - 1;
+    int32_t top_y = (int32_t)(center_y - ceilf(window_height/2.0f));
+    int32_t bottom_y = top_y + window_height - 1;
+
+    // Fast path for textures with no rotation and either no scaling or just flipped horizontally
+    if(rotation_radians == 0.0f &&
+       (x_scale == 1.0f || x_scale == -1.0f) &&
+        y_scale == 1.0f){
+
+        // Iterate over each pixel in the display that is occupied by the texture, 
+        // find the texture pixel and put it in the display buffer
+        int32_t x_start = 0; // x position within the sprite window to start
+        int32_t y_start = 0; // y position within the sprite window to start
+
+        // Distance to jump in the texture array between the last pixel
+        // in one row and the first pixel in the next row
+        int32_t sprite_draw_width = window_width; 
+        
+        // If the texture is hanging off the edge of the display, start
+        // drawing midway through the texture
+        if(left_x < 0){
+            x_start = left_x * -1;
+            sprite_draw_width -= x_start;
+        }
+
+        int32_t sprite_draw_height = window_height;
+        if(top_y < 0){
+            y_start = top_y * -1;
+            sprite_draw_height -= y_start;
+        }
+
+        if(right_x >= SCREEN_WIDTH){
+            sprite_draw_width -= (right_x - SCREEN_WIDTH + 1);
+        }
+        if(bottom_y >= SCREEN_HEIGHT){
+            sprite_draw_height -= (bottom_y - SCREEN_HEIGHT +1);
+        }
+
+        // Distance to jump in the display array from the end of one
+        // row in the texture to the start of the next row
+        uint32_t next_dest_row_offset = SCREEN_WIDTH - sprite_draw_width;
+        int32_t y, x;
+        
+        // The offset into the display array for the start of each texture row.
+        uint32_t dest_offset = (top_y + y_start) * SCREEN_WIDTH + left_x + x_start;
+        
+        // The direction we'll be drawing onto the display.  1 is right-to-left
+        // -1 is left-to-right (for horizontally flipped textures).
+        int32_t dest_increment = 1;
+
+        // If the sprite is flipped horizontally, draw from right to left.
+        if(x_scale == -1.0f){
+            dest_offset += (sprite_draw_width-1);
+            dest_increment = -1;
+            next_dest_row_offset = SCREEN_WIDTH + sprite_draw_width;
+        }
+        for(y=y_start;y < y_start + sprite_draw_height;y++){
+            for(x=x_start;x < x_start + sprite_draw_width;x++){
+                uint32_t src_offset = y * pixels_stride + x;
+                float src_alpha = 1.0f;
+                uint16_t src_color = texture->get_pixel(texture, offset+src_offset, &src_alpha);
+                if(src_color != transparent_color || src_color == ENGINE_NO_TRANSPARENCY_COLOR){
+                    active_screen_buffer[dest_offset] = shader->execute(active_screen_buffer[dest_offset], src_color, alpha*src_alpha, shader);                   
+                }
+                dest_offset+=dest_increment;
+            }
+            dest_offset += next_dest_row_offset;  
+        }
+        return;
+    }
 
     // ENGINE_PERFORMANCE_CYCLES_START();
     float inverse_x_scale = 1.0f / x_scale;

--- a/src/resources/engine_texture_resource.c
+++ b/src/resources/engine_texture_resource.c
@@ -232,6 +232,79 @@ uint16_t texture_resource_get_indexed_pixel(texture_resource_class_obj_t *textur
 }
 
 
+uint16_t texture_resource_get_1bit_pixel(
+    texture_resource_class_obj_t *texture, 
+    uint32_t pixel_offset, 
+    float *out_alpha){
+    mp_obj_array_t *data = texture->data;
+    mp_obj_array_t *colors = texture->colors;
+     
+    // Get the byte containing the pixel
+    uint8_t byte_containing_pixel = ((uint8_t*)data->items)[pixel_offset/8];
+
+    // Get number of places to shift to the right
+    /*  pixel offset    pixel_offset%8  bits to shift right
+        0               0               7
+        1               1               6
+        ...             ...             ...
+        7               7               0
+        8               0               7
+        
+        Therefore,
+        bits_to_shift = 7 - pixel_offset%8
+        Which is the same as 7 - (pixel_offset&7)
+    */
+    byte_containing_pixel >>= 7 - (pixel_offset&7);
+    uint8_t color_index = byte_containing_pixel & 0x01; // We only want the rightmost bit
+    return ((uint16_t*)colors->items)[color_index];
+}
+
+
+uint16_t texture_resource_get_4bit_pixel(
+    texture_resource_class_obj_t *texture, 
+    uint32_t pixel_offset, 
+    float *out_alpha){
+    mp_obj_array_t *data = texture->data;
+    mp_obj_array_t *colors = texture->colors;
+
+    // Get the byte containing the pixel
+    uint8_t byte_containing_pixel = ((uint8_t*)data->items)[pixel_offset/2];
+
+    // Get the number of places to shift to the right.
+    /*
+      Pixels with an even-numbered pixel_offset sit in the left half of the 
+      byte and need to be shifted 4 bits to the right.    
+      We don't need to shift pixels with an odd-numbered pixel_offset.
+
+      pixel_offset & 1 returns 1 if the pixel_offset is odd
+      
+      (pixel_offset & 1) ^ 1) returns 1 if the pixel_offset is even
+      
+      ((pixel_offset & 1) ^ 1) << 2 returns 4 if the pixel_offset is even and 
+      0 if it is odd      
+    */
+
+    byte_containing_pixel >>= ((pixel_offset & 1) ^ 1) << 2;
+
+    uint8_t color_index = byte_containing_pixel & 0x0F; // We only want the right 4 bits
+    return ((uint16_t*)colors->items)[color_index];
+}
+
+
+uint16_t texture_resource_get_8bit_pixel(
+    texture_resource_class_obj_t *texture, 
+    uint32_t pixel_offset, 
+    float *out_alpha){
+    mp_obj_array_t *data = texture->data;
+    mp_obj_array_t *colors = texture->colors;
+    
+    // Each pixel_offset is contained in exactly one byte
+
+    uint8_t color_index = ((uint8_t*)data->items)[pixel_offset];
+    return ((uint16_t*)colors->items)[color_index];
+}
+
+
 uint16_t texture_resource_get_16bit_rgb565(texture_resource_class_obj_t *texture, uint32_t pixel_offset, float *out_alpha){
     mp_obj_array_t *data = texture->data;
     return ((uint16_t*)data->items)[pixel_offset];
@@ -521,7 +594,19 @@ void create_from_file(texture_resource_class_obj_t *self, mp_obj_t filepath, mp_
 
     // Assign a function for getting pixels from texture resource
     if(self->bit_depth < 16){
-        self->get_pixel = texture_resource_get_indexed_pixel;
+        switch(self->bit_depth){
+            case 1:
+                self->get_pixel = texture_resource_get_1bit_pixel;
+                break;
+            case 4:
+                self->get_pixel = texture_resource_get_4bit_pixel;
+                break;
+            case 8:
+                self->get_pixel = texture_resource_get_8bit_pixel;
+                break;
+            default:
+                self->get_pixel = texture_resource_get_indexed_pixel;
+        }
     }else{
         if((self->combined_masks == 65535 && self->alpha_mask == 0) || self->combined_masks == 0){   // RGB565
             self->get_pixel = texture_resource_get_16bit_rgb565;


### PR DESCRIPTION
Add specialized get_pixel functions for textures of bit depths 1, 4 and 8 to improve pixel lookup speed.
Add a fast path in engine_draw_blit for textures that have no scaling or rotation.
